### PR TITLE
Add file path as parameter, upload the report as CircleCI artifact

### DIFF
--- a/orb.yml
+++ b/orb.yml
@@ -38,7 +38,7 @@ commands:
             fi
 
             # Post the report and save URL
-            REPORT_URL=$(curl -F 'html=@${REPORT_FILE}' https://unmock-ci.azurewebsites.net/reports)
+            REPORT_URL=$(curl -F 'html=@"'"${REPORT_FILE}"'"' https://unmock-ci.azurewebsites.net/reports)
             echo "Uploaded the report to ${REPORT_URL}"
 
             # If running for a pull-request, try sending a notification

--- a/orb.yml
+++ b/orb.yml
@@ -10,6 +10,7 @@ commands:
     parameters:
       file:
         type: string
+        description: "Path to test report"
         default: "__unmock__/unmock-report.html"
     steps:
       - run:

--- a/orb.yml
+++ b/orb.yml
@@ -50,7 +50,7 @@ commands:
             BUILD_ARTIFACTS_URL=https://circleci.com/api/v1.1/project/github/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/${CIRCLE_BUILD_NUM}/artifacts
             echo "Fetching artifact URL from: ${BUILD_ARTIFACTS_URL}"
             REPORT_ARTIFACT_URL=$(curl --fail ${BUILD_ARTIFACTS_URL} | jq .[0].url)  # TODO Handle multiple artifacts
-            echo "Your report lives here: ${REPORT_ARTIFACT_URL}"
+            echo "Your report lives here: ${REPORT_ARTIFACT_URL}. Enjoy!"
             echo "export REPORT_ARTIFACT_URL=${REPORT_ARTIFACT_URL}" >> $BASH_ENV
       - run:
           name: Post notification to the pull request if Unmock GitHub app is installed
@@ -81,7 +81,6 @@ commands:
             else
               echo "Not a pull-request, skipping sending notification."
             fi
-            echo "Your test report lives here: ${REPORT_ARTIFACT_URL}. Enjoy!"
 
 examples:
   upload:

--- a/orb.yml
+++ b/orb.yml
@@ -33,8 +33,8 @@ check_report: &check_report
     fi
 
 commands:
-  store:
-    description: "Stores Unmock test report as a CircleCI artifact"
+  upload:
+    description: "Uploads unmock jest-reporter results and makes a note on your PR if you have a GH integration. The orb is in early alpha stage, and its usage should be considered experimental. Note that the uploaded report will be publicly available on the internet. If your tests in CircleCI use real API keys or tokens for HTTP requests, this orb is not (yet) for you. Any and all feedback is appreciated!"
     parameters: *parameters
     steps:
       - run: *check_report
@@ -42,38 +42,32 @@ commands:
           path: << parameters.file >>
       - jq/install
       - run:
-          name: "Build artifacts URL"
+          name: "Determine artifact URL"
           command: |
-            ARTIFACTS_URL=https://circleci.com/api/v1.1/project/github/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/${CIRCLE_BUILD_NUM}/artifacts
-            echo "URL: ${ARTIFACTS_URL}"
-  upload:
-    description: "Uploads unmock jest-reporter results and makes a note on your PR if you have a GH integration. The orb is in early alpha stage, and its usage should be considered experimental. Note that the uploaded report will be publicly available on the internet. If your tests in CircleCI use real API keys or tokens for HTTP requests, this orb is not (yet) for you. Any and all feedback is appreciated!"
-    parameters: *parameters
-    steps:
-      - run: *check_report
-      - run:
-          name: Print BUILD_URL
-          command: |
-            echo "Your test report lives here: ${CIRCLE_BUILD_URL}"
-      - run:
-          name: Upload file and post notification
-          command: |
-            # Exit script if a statement returns a non-true return value.
             set -o errexit
-
-            # Use the error status of the first failure, rather than that of the last item in a pipeline.
             set -o pipefail
 
-            REPORT_FILE=<< parameters.file >>
+            BUILD_ARTIFACTS_URL=https://circleci.com/api/v1.1/project/github/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/${CIRCLE_BUILD_NUM}/artifacts
+            echo "Fetching artifact URL from: ${BUILD_ARTIFACTS_URL}"
+            REPORT_ARTIFACT_URL=$(curl --fail ${BUILD_ARTIFACTS_URL} | jq .[0].url)  # TODO Handle multiple artifacts
+            echo "Your report lives here: ${REPORT_ARTIFACT_URL}"
+            echo "export REPORT_ARTIFACT_URL=${REPORT_ARTIFACT_URL}" >> $BASH_ENV
+      - run:
+          name: Post notification
+          command: |
+            set -o errexit
+            set -o pipefail
 
-            # Post the report and save URL
-            REPORT_URL=$(curl -F 'html=@"'"${REPORT_FILE}"'"' https://unmock-ci.azurewebsites.net/reports)
-            echo "Uploaded the report to ${REPORT_URL}"
+            if [ -z ${REPORT_ARTIFACT_URL} ];
+            then
+              echo "REPORT_ARTIFACT_URL empty or undefined, exiting";
+              exit 0;
+            fi
 
             # If running for a pull-request, try sending a notification
             if [ ! -z ${CIRCLE_PULL_REQUEST} ];
             then
-              REPLY_CODE=$(curl -i --header "Content-Type: application/json" --request POST --data '{"pr":"'"${CIRCLE_PULL_REQUEST}"'","sha1":"'"${CIRCLE_SHA1}"'","url":"'"${REPORT_URL}"'"}' https://unmock-ci.azurewebsites.net/notifications/github |
+              REPLY_CODE=$(curl -i --header "Content-Type: application/json" --request POST --data '{"pr":"'"${CIRCLE_PULL_REQUEST}"'","sha1":"'"${CIRCLE_SHA1}"'","url":"'"${REPORT_ARTIFACT_URL}"'"}' https://unmock-ci.azurewebsites.net/notifications/github |
               head -n 1 |  # Keep first line of response
               cut -d$' ' -f2)  # Split the line and take the second value (status code)
 
@@ -87,7 +81,7 @@ commands:
             else
               echo "Not a pull-request, skipping sending notification."
             fi
-            echo "Your test report lives here: ${REPORT_URL}. Enjoy!"
+            echo "Your test report lives here: ${REPORT_ARTIFACT_URL}. Enjoy!"
 
 examples:
   upload:

--- a/orb.yml
+++ b/orb.yml
@@ -9,27 +9,40 @@ commands:
     description: "Uploads unmock jest-reporter results and makes a note on your PR if you have a GH integration. The orb is in early alpha stage, and its usage should be considered experimental. Note that the uploaded report will be publicly available on the internet. If your tests in CircleCI use real API keys or tokens for HTTP requests, this orb is not (yet) for you. Any and all feedback is appreciated!"
     steps:
       - run:
-          name: Set exits
+          name: Upload file and post notification
           command: |
-            # Exit script if you try to use an uninitialized variable.
-            set -o nounset
-
             # Exit script if a statement returns a non-true return value.
             set -o errexit
 
             # Use the error status of the first failure, rather than that of the last item in a pipeline.
             set -o pipefail
-      - run:
-          name: Upload file and post notification
-          command: |
+
+            # Post the report and save URL
             REPORT_URL=$(curl -F 'html=@__unmock__/unmock-report.html' https://unmock-ci.azurewebsites.net/reports)
-            echo "Uploaded the report to $REPORT_URL"
-            if [ ! -z $CIRCLE_PULL_REQUEST ]; then curl --header "Content-Type: application/json" --request POST --data '{"pr":"'"$CIRCLE_PULL_REQUEST"'","sha1":"'"$CIRCLE_SHA1"'","url":"'"$REPORT_URL"'"}' https://unmock-ci.azurewebsites.net/notifications/github; fi
-            echo "Your test report lives here: $REPORT_URL. Enjoy!"
+            echo "Uploaded the report to ${REPORT_URL}"
+
+            # If running for a pull-request, try sending a notification
+            if [ ! -z ${CIRCLE_PULL_REQUEST} ];
+            then
+              REPLY_CODE=$(curl -i --header "Content-Type: application/json" --request POST --data '{"pr":"'"${CIRCLE_PULL_REQUEST}"'","sha1":"'"${CIRCLE_SHA1}"'","url":"'"${REPORT_URL}"'"}' https://unmock-ci.azurewebsites.net/notifications/github |
+              head -n 1 |  # Keep first line of response
+              cut -d$' ' -f2)  # Split the line and take the second value (status code)
+
+              if [ ! ${REPLY_CODE} == 200 ];
+              then
+                echo "Failed sending notification, got reply with code: ${REPLY_CODE}";
+              else
+                echo "Sent notification."
+              fi;
+
+            else
+              echo "Not a pull-request, skipping sending notification."
+            fi
+            echo "Your test report lives here: ${REPORT_URL}. Enjoy!"
 
 examples:
   upload:
-    description: "Upload your Unmock jest-reporter files."
+    description: "Upload your Unmock test reporter files."
     usage:
       version: 2.1
       orbs:

--- a/orb.yml
+++ b/orb.yml
@@ -73,7 +73,7 @@ commands:
 
               if [ ! ${REPLY_CODE} == 200 ];
               then
-                echo "Failed sending notification, got reply with code: ${REPLY_CODE}";
+                echo "Failed sending notification with code ${REPLY_CODE}.";
               else
                 echo "Sent notification."
               fi;

--- a/orb.yml
+++ b/orb.yml
@@ -34,7 +34,7 @@ check_report: &check_report
 
 commands:
   upload:
-    description: "Uploads unmock jest-reporter results and makes a note on your PR if you have a GH integration. The orb is in early alpha stage, and its usage should be considered experimental. Note that the uploaded report will be publicly available on the internet. If your tests in CircleCI use real API keys or tokens for HTTP requests, this orb is not (yet) for you. Any and all feedback is appreciated!"
+    description: "Stores Unmock test report as a CircleCI artifact and makes a note on your PR if you have GitHub integration. The orb is in early alpha stage, and its usage should be considered experimental. Note that the uploaded report will be publicly available on the internet if your CircleCI project is public. Any and all feedback is appreciated!"
     parameters: *parameters
     steps:
       - run: *check_report

--- a/orb.yml
+++ b/orb.yml
@@ -42,9 +42,10 @@ commands:
           path: << parameters.file >>
       - jq/install
       - run:
-        command: |
-          ARTIFACTS_URL=https://circleci.com/api/v1.1/project/github/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/${CIRCLE_BUILD_NUM}/artifacts
-          echo "URL: ${ARTIFACTS_URL}"
+          name: "Build artifacts URL"
+          command: |
+            ARTIFACTS_URL=https://circleci.com/api/v1.1/project/github/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/${CIRCLE_BUILD_NUM}/artifacts
+            echo "URL: ${ARTIFACTS_URL}"
   upload:
     description: "Uploads unmock jest-reporter results and makes a note on your PR if you have a GH integration. The orb is in early alpha stage, and its usage should be considered experimental. Note that the uploaded report will be publicly available on the internet. If your tests in CircleCI use real API keys or tokens for HTTP requests, this orb is not (yet) for you. Any and all feedback is appreciated!"
     parameters: *parameters
@@ -62,6 +63,8 @@ commands:
 
             # Use the error status of the first failure, rather than that of the last item in a pipeline.
             set -o pipefail
+
+            REPORT_FILE=<< parameters.file >>
 
             # Post the report and save URL
             REPORT_URL=$(curl -F 'html=@"'"${REPORT_FILE}"'"' https://unmock-ci.azurewebsites.net/reports)

--- a/orb.yml
+++ b/orb.yml
@@ -53,7 +53,7 @@ commands:
             echo "Your report lives here: ${REPORT_ARTIFACT_URL}"
             echo "export REPORT_ARTIFACT_URL=${REPORT_ARTIFACT_URL}" >> $BASH_ENV
       - run:
-          name: Post notification
+          name: Post notification to the pull request if Unmock GitHub app is installed
           command: |
             set -o errexit
             set -o pipefail
@@ -64,7 +64,7 @@ commands:
               exit 0;
             fi
 
-            # If running for a pull-request, try sending a notification
+            # Try sending a notification if pull-request, allow failure.
             if [ ! -z ${CIRCLE_PULL_REQUEST} ];
             then
               REPLY_CODE=$(curl -i --header "Content-Type: application/json" --request POST --data '{"pr":"'"${CIRCLE_PULL_REQUEST}"'","sha1":"'"${CIRCLE_SHA1}"'","url":"'"${REPORT_ARTIFACT_URL}"'"}' https://unmock-ci.azurewebsites.net/notifications/github |
@@ -89,7 +89,7 @@ examples:
     usage:
       version: 2.1
       orbs:
-        unmock: unmock/unmock@0.0.8
+        unmock: unmock/unmock@volatile
       jobs:
         build:
           docker:

--- a/orb.yml
+++ b/orb.yml
@@ -4,15 +4,56 @@ description: >
   Repo Home: https://github.com/unmock/unmock-orb
   Website: https://www.unmock.io/
 
+orbs:
+  jq: circleci/jq@1.9.0
+
+parameters: &parameters
+  file:
+    type: string
+    description: "Path to test report"
+    default: "__unmock__/unmock-report.html"
+
+check_report: &check_report
+  name: Check report exists
+  command: |
+    REPORT_FILE=<< parameters.file >>
+
+    if [ -z ${REPORT_FILE} ];
+    then
+      echo "Empty or missing environment variable: REPORT_FILE";
+      exit 1;
+    fi;
+
+    if [ -f ${REPORT_FILE} ];  # File exists
+    then
+        echo "Found file, proceeding with: ${REPORT_FILE}"
+    else
+        echo "Report not found: ${REPORT_FILE}, exiting."
+        exit 1;
+    fi
+
 commands:
+  store:
+    description: "Stores Unmock test report as a CircleCI artifact"
+    parameters: *parameters
+    steps:
+      - run: *check_report
+      - store_artifacts:
+          path: << parameters.file >>
+      - jq/install
+      - run:
+        command: |
+          ARTIFACTS_URL=https://circleci.com/api/v1.1/project/github/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/${CIRCLE_BUILD_NUM}/artifacts
+          echo "URL: ${ARTIFACTS_URL}"
   upload:
     description: "Uploads unmock jest-reporter results and makes a note on your PR if you have a GH integration. The orb is in early alpha stage, and its usage should be considered experimental. Note that the uploaded report will be publicly available on the internet. If your tests in CircleCI use real API keys or tokens for HTTP requests, this orb is not (yet) for you. Any and all feedback is appreciated!"
-    parameters:
-      file:
-        type: string
-        description: "Path to test report"
-        default: "__unmock__/unmock-report.html"
+    parameters: *parameters
     steps:
+      - run: *check_report
+      - run:
+          name: Print BUILD_URL
+          command: |
+            echo "Your test report lives here: ${CIRCLE_BUILD_URL}"
       - run:
           name: Upload file and post notification
           command: |
@@ -21,22 +62,6 @@ commands:
 
             # Use the error status of the first failure, rather than that of the last item in a pipeline.
             set -o pipefail
-
-            REPORT_FILE=<< parameters.file >>
-
-            if [ -z ${REPORT_FILE} ];
-            then
-              echo "Empty or missing environment variable: REPORT_FILE";
-              exit 1;
-            fi;
-
-            if [ -f ${REPORT_FILE} ];  # File exists
-            then
-                echo "Uploading file: ${REPORT_FILE}"
-            else
-                echo "Report not found: ${REPORT_FILE}, exiting."
-                exit 1;
-            fi
 
             # Post the report and save URL
             REPORT_URL=$(curl -F 'html=@"'"${REPORT_FILE}"'"' https://unmock-ci.azurewebsites.net/reports)

--- a/orb.yml
+++ b/orb.yml
@@ -7,6 +7,10 @@ description: >
 commands:
   upload:
     description: "Uploads unmock jest-reporter results and makes a note on your PR if you have a GH integration. The orb is in early alpha stage, and its usage should be considered experimental. Note that the uploaded report will be publicly available on the internet. If your tests in CircleCI use real API keys or tokens for HTTP requests, this orb is not (yet) for you. Any and all feedback is appreciated!"
+    parameters:
+      file:
+        type: string
+        default: "__unmock__/unmock-report.html"
     steps:
       - run:
           name: Upload file and post notification
@@ -17,8 +21,24 @@ commands:
             # Use the error status of the first failure, rather than that of the last item in a pipeline.
             set -o pipefail
 
+            REPORT_FILE=<< parameters.file >>
+
+            if [ -z ${REPORT_FILE} ];
+            then
+              echo "Empty or missing environment variable: REPORT_FILE";
+              exit 1;
+            fi;
+
+            if [ -f ${REPORT_FILE} ];  # File exists
+            then
+                echo "Uploading file: ${REPORT_FILE}"
+            else
+                echo "Report not found: ${REPORT_FILE}, exiting."
+                exit 1;
+            fi
+
             # Post the report and save URL
-            REPORT_URL=$(curl -F 'html=@__unmock__/unmock-report.html' https://unmock-ci.azurewebsites.net/reports)
+            REPORT_URL=$(curl -F 'html=@${REPORT_FILE}' https://unmock-ci.azurewebsites.net/reports)
             echo "Uploaded the report to ${REPORT_URL}"
 
             # If running for a pull-request, try sending a notification
@@ -74,4 +94,5 @@ examples:
 
             # run tests!
             - run: yarn test
-            - unmock/upload
+            - unmock/upload:
+                file: "__unmock__/report.html"


### PR DESCRIPTION
- Add `file` parameter with default `__unmock__/unmock-report.html`
- Get rid of uploading the report to our server: instead, store the report as a CircleCI artifact 
- To determine the URL to the artifact, make a call to the CircleCI API at `https://circleci.com/api/v1.1/project/github/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/${CIRCLE_BUILD_NUM}/artifacts`. For example: [https://circleci.com/api/v1.1/project/github/unmock/unmock-orb-example/28/artifacts](https://circleci.com/api/v1.1/project/github/unmock/unmock-orb-example/28/artifacts). See [this SO question](https://stackoverflow.com/questions/46880788/circle-ci-2-0-artifacts-url).
- Parse the CircleCI API response with `jq`

TODO later:
- [ ]  Assumes the unmock report is the first artifact: notification may point to the wrong artifact if there are multiple artifacts
- [ ]  Does the call to CircleCI API from inside the orb fail with 401 if the project is private?