### PR TITLE
Dev 0.0.14: Commands for Unmock server

### DIFF
--- a/orb.yml
+++ b/orb.yml
@@ -50,7 +50,7 @@ commands:
           command: |
             set -o errexit
             set -o pipefail
-            git clone --single-branch --branch unmock-server https://github.com/unmock/unmock-js.git
+            git clone --single-branch --branch dev https://github.com/unmock/unmock-js.git
             cd unmock-js && npm i && npm run compile
       - run:
           name: "Prepare certificate, start Unmock proxy and server"

--- a/orb.yml
+++ b/orb.yml
@@ -50,7 +50,7 @@ commands:
           command: |
             set -o errexit
             set -o pipefail
-            git clone --single-branch --branch unmock-server-dev https://github.com/unmock/unmock-js.git
+            git clone --single-branch --branch unmock-server https://github.com/unmock/unmock-js.git
             cd unmock-js && npm i
       - run:
           name: "Prepare certificate, start Unmock proxy and server"

--- a/orb.yml
+++ b/orb.yml
@@ -35,22 +35,49 @@ check_report: &check_report
 commands:
   start:
     description: "Starts Unmock server and proxy and sets the proxy environment variables."
+    parameters:
+      domains:
+        type: string
+        description: "List of domains you want to mock, required for generating certificates"
+        default: "petstore.swagger.io,example.com"
     steps:
       - run:
-          name: "Checkout repo"
+          name: "Checkout Unmock server and prepare certificate"
           command: |
             set -o errexit
             set -o pipefail
-            git clone --single-branch --branch unmock-server git@github.com:unmock/unmock-js.git
-            cd unmock-js && npm i && npm run compile
-            openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -days 365 -nodes -subj '/CN=*.swagger.io'
-            node unmock-js/packages/unmock-server/index.js &
+            git clone --single-branch --branch unmock-server-dev https://github.com/unmock/unmock-js.git
+            cd unmock-js && npm i
+      - run:
+          name: "Start server"
+          command: |
+            bash unmock-js/packages/unmock-server/scripts/prepare-cert.sh << parameters.domains >>
+            DEBUG=unmock* node unmock-js/packages/unmock-server/index.js
+          background: true
+      - run:
+          name: "Sleep"
+          command: |
+            sleep 5
+            PROXY_URL=http://localhost:8008
+            echo "export HTTP_PROXY=${PROXY_URL}" >> $BASH_ENV
+            echo "export HTTPS_PROXY=${PROXY_URL}" >> $BASH_ENV
+            echo "export http_proxy=${PROXY_URL}" >> $BASH_ENV
+            echo "export https_proxy=${PROXY_URL}" >> $BASH_ENV
+            echo "export SSL_CERT_FILE=cert.pem" >> $BASH_ENV
+  call:
+    description: "Make a test call to Unmock server"
+    steps:
+      - run:
+          name: "Test curl"
+          command: |
+            curl -i http://petstore.swagger.io/v2/pet/23
   stop:
     description: "Stop the server"
     steps:
       - run:
           name: "Kill Node.js processes"
-          command: pgrep node | xargs kill
+          command: |
+            echo $(pgrep node)  # TODO Kill
   upload:
     description: "Stores Unmock test report as a CircleCI artifact and sends a link in your GitHub PR if you have Unmock GitHub app installed (https://github.com/apps/unmock). Note that the uploaded report will be publicly available on the internet if your CircleCI project is public. Any and all feedback is appreciated!"
     parameters: *parameters

--- a/orb.yml
+++ b/orb.yml
@@ -75,7 +75,7 @@ commands:
           name: "Test curl"
           command: |
             curl -i http://petstore.swagger.io/v2/pet/23
-  set_code:
+  set:
     description: "Sets unmock to return specific status code"
     parameters:
       code:

--- a/orb.yml
+++ b/orb.yml
@@ -75,6 +75,17 @@ commands:
           name: "Test curl"
           command: |
             curl -i http://petstore.swagger.io/v2/pet/23
+  set_code:
+    description: "Sets unmock to return specific status code"
+    parameters:
+      code:
+        type: integer
+        description: "Status code you want Unmock to return"
+        default: 200
+    steps:
+      - run:
+          name: "Set Unmock status code"
+          command: curl -X POST http://localhost:8000/api?code=<<parameters.code>>
   stop:
     description: "Stop the server"
     steps:

--- a/orb.yml
+++ b/orb.yml
@@ -42,20 +42,20 @@ commands:
         default: "petstore.swagger.io,example.com"
     steps:
       - run:
-          name: "Checkout Unmock server and prepare certificate"
+          name: "Checkout Unmock server"
           command: |
             set -o errexit
             set -o pipefail
             git clone --single-branch --branch unmock-server-dev https://github.com/unmock/unmock-js.git
             cd unmock-js && npm i
       - run:
-          name: "Start server"
+          name: "Prepare certificate, start Unmock proxy and server"
           command: |
             bash unmock-js/packages/unmock-server/scripts/prepare-cert.sh << parameters.domains >>
             DEBUG=unmock* node unmock-js/packages/unmock-server/index.js
           background: true
       - run:
-          name: "Sleep"
+          name: "Set environment variables"
           command: |
             sleep 5
             PROXY_URL=http://localhost:8008

--- a/orb.yml
+++ b/orb.yml
@@ -51,7 +51,7 @@ commands:
             set -o errexit
             set -o pipefail
             git clone --single-branch --branch unmock-server https://github.com/unmock/unmock-js.git
-            cd unmock-js && npm i
+            cd unmock-js && npm i && npm run compile
       - run:
           name: "Prepare certificate, start Unmock proxy and server"
           command: |

--- a/orb.yml
+++ b/orb.yml
@@ -33,6 +33,24 @@ check_report: &check_report
     fi
 
 commands:
+  start:
+    description: "Starts Unmock server and proxy and sets the proxy environment variables."
+    steps:
+      - run:
+          name: "Checkout repo"
+          command: |
+            set -o errexit
+            set -o pipefail
+            git clone --single-branch --branch unmock-server git@github.com:unmock/unmock-js.git
+            cd unmock-js && npm i && npm run compile
+            openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -days 365 -nodes -subj '/CN=*.swagger.io'
+            node unmock-js/packages/unmock-server/index.js &
+  stop:
+    description: "Stop the server"
+    steps:
+      - run:
+          name: "Kill Node.js processes"
+          command: pgrep node | xargs kill
   upload:
     description: "Stores Unmock test report as a CircleCI artifact and sends a link in your GitHub PR if you have Unmock GitHub app installed (https://github.com/apps/unmock). Note that the uploaded report will be publicly available on the internet if your CircleCI project is public. Any and all feedback is appreciated!"
     parameters: *parameters

--- a/orb.yml
+++ b/orb.yml
@@ -42,6 +42,10 @@ commands:
         default: "petstore.swagger.io,example.com"
     steps:
       - run:
+          name: "Install Node.js"
+          command: |
+            sudo apt-get update && sudo apt-get install -y nodejs npm
+      - run:
           name: "Checkout Unmock server"
           command: |
             set -o errexit


### PR DESCRIPTION
First step in using unmock-server as proxy.

Still a lot to do:
- [ ]  Requires installing Node.js
- [ ]  Requires cloning unmock-js repository
- [ ]  Needs description of what it needs to work
- [ ]  Needs a command to kill the servers