### PR TITLE
Add contributing necessities

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+<!--
+  Thanks for making a pull request! 
+  
+  Before submitting, please read our contributing guidelines:
+  https://github.com/unmock/unmock-orb#contributing
+
+  Have any questions? 
+  Feel free to ask in this PR and one of our maintainers will be happy to help 🙌
+-->
+
+Fixes #<issue number>
+
+## Description
+
+<!-- Write a brief description of the changes introduced by this PR -->
+
+## How to test 
+
+<!-- What steps can we take to test that your code is working properly -->

--- a/README.md
+++ b/README.md
@@ -46,3 +46,11 @@ Alternatively, you can use `promote` command to promote a development version to
 circleci orb publish promote unmock/unmock@dev:0.0.x patch
 # Push git tags as above
 ```
+
+## Contributing
+
+Thanks for wanting to contribute! We will soon have a contributing page
+detaling how to contribute. Meanwhile, feel free to star this repository, open issues
+and ask for more features and support.
+
+Please note that this project is governed by the [Unmock Community Code of Conduct](https://github.com/unmock/code-of-conduct). By participating in this project, you agree to abide by its terms.


### PR DESCRIPTION
I've been adding contributing guides and pull request templates to each repo, but I wanted to check before adding them to this one. If we're open to contributions, then I'd vote to merge this as a start. If we're not - then maybe we should clarify that in the README.